### PR TITLE
Fix event loop handling for TTS

### DIFF
--- a/video_production_pipeline.py
+++ b/video_production_pipeline.py
@@ -709,14 +709,10 @@ class UltimateVideoProductionPipeline:
             with open(text_file, 'r', encoding='utf-8') as f:
                 text_content = f.read().strip()
             
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                loop.run_until_complete(
-                    self.tts_processor.text_to_speech(text_content, voice_file, config)
-                )
-            finally:
-                loop.close()
+            # Use asyncio.run to ensure event loop is properly managed
+            asyncio.run(
+                self.tts_processor.text_to_speech(text_content, voice_file, config)
+            )
             
             # Получаем длительность озвучки
             audio_duration = self.get_audio_duration(voice_file)


### PR DESCRIPTION
## Summary
- manage asyncio loop with `asyncio.run`
- remove manual event loop closing logic

## Testing
- `python3 -m py_compile video_production_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_6880b0ad3e10832b99c15510c0dbf848